### PR TITLE
Add more example: simple page to fetch ng-query repository

### DIFF
--- a/packages/playground/src/app/app.component.ts
+++ b/packages/playground/src/app/app.component.ts
@@ -28,6 +28,16 @@ import { RouterModule } from '@angular/router';
                 routerLinkActive="active"
                 aria-current="page"
                 routerLink=""
+                >Simple</a
+              >
+            </li>
+
+            <li class="nav-item">
+              <a
+                class="nav-link"
+                routerLinkActive="active"
+                aria-current="page"
+                routerLink="basic"
                 >Basic</a
               >
             </li>

--- a/packages/playground/src/app/github.service.ts
+++ b/packages/playground/src/app/github.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { QueryProvider } from '@ngneat/ng-query';
+
+interface Repository {
+  name: string;
+  description: string;
+  subscribers_count: number;
+  stargazers_count: number;
+  forks_count: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GithubApiService {
+  http = inject(HttpClient);
+  useQuery = inject(QueryProvider);
+
+  getRepository(repositoryName: string) {
+    return this.useQuery(['repository', repositoryName], () =>
+      this.http.get<Repository>(
+        `https://api.github.com/repos/${repositoryName}`
+      )
+    );
+  }
+}

--- a/packages/playground/src/app/simple-page/simple-page.component.ts
+++ b/packages/playground/src/app/simple-page/simple-page.component.ts
@@ -1,16 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { Component, inject } from '@angular/core';
-import { QueryProvider } from '@ngneat/ng-query';
+import { Component } from '@angular/core';
 import { SubscribeModule } from '@ngneat/subscribe';
-
-interface Repository {
-  name: string;
-  description: string;
-  subscribers_count: number;
-  stargazers_count: number;
-  forks_count: number;
-}
+import { GithubApiService } from '../github.service';
 
 @Component({
   standalone: true,
@@ -21,21 +12,19 @@ interface Repository {
       <p *ngIf="repo.error">An error has occurred: {{ repo.error }}</p>
 
       <div *ngIf="repo.isSuccess">
-        <h1>{{repo.data.name }}</h1>
-        <p>{{repo.data.description }}</p>
-        <strong>👀 {{repo.data.subscribers_count }}</strong>
-        <strong>✨ {{repo.data.stargazers_count }}</strong>
-        <strong>🍴 {{repo.data.forks_count }}</strong>
-        <div>{{repo.isFetching ? "Updating..." :  ""}}</div>
+        <h1>{{ repo.data.name }}</h1>
+        <p>{{ repo.data.description }}</p>
+        <strong>👀 {{ repo.data.subscribers_count }}</strong>
+        <strong>✨ {{ repo.data.stargazers_count }}</strong>
+        <strong>🍴 {{ repo.data.forks_count }}</strong>
       </div>
+      
+      <div *ngIf="repo.isFetching">Updating...</div>
     </ng-container>
   `,
 })
 export class SimplePageComponent {
-  useQuery = inject(QueryProvider);
-  http = inject(HttpClient);
+  constructor(private githubApiService: GithubApiService) {}
 
-  repo$ = this.useQuery(['repoData'], () =>
-    this.http.get<Repository>('https://api.github.com/repos/ngneat/ng-query')
-  );
+  repo$ = this.githubApiService.getRepository('ngneat/ng-query');
 }

--- a/packages/playground/src/app/simple-page/simple-page.component.ts
+++ b/packages/playground/src/app/simple-page/simple-page.component.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { Component, inject } from '@angular/core';
+import { QueryProvider } from '@ngneat/ng-query';
+import { SubscribeModule } from '@ngneat/subscribe';
+
+interface Repository {
+  name: string;
+  description: string;
+  subscribers_count: number;
+  stargazers_count: number;
+  forks_count: number;
+}
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, SubscribeModule],
+  template: `
+    <ng-container *subscribe="repo$ as repo">
+      <p *ngIf="repo.isLoading">Loading...</p>
+      <p *ngIf="repo.error">An error has occurred: {{ repo.error }}</p>
+
+      <div *ngIf="repo.isSuccess">
+        <h1>{{repo.data.name }}</h1>
+        <p>{{repo.data.description }}</p>
+        <strong>👀 {{repo.data.subscribers_count }}</strong>
+        <strong>✨ {{repo.data.stargazers_count }}</strong>
+        <strong>🍴 {{repo.data.forks_count }}</strong>
+        <div>{{repo.isFetching ? "Updating..." :  ""}}</div>
+      </div>
+    </ng-container>
+  `,
+})
+export class SimplePageComponent {
+  useQuery = inject(QueryProvider);
+  http = inject(HttpClient);
+
+  repo$ = this.useQuery(['repoData'], () =>
+    this.http.get<Repository>('https://api.github.com/repos/ngneat/ng-query')
+  );
+}

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -3,11 +3,12 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
 import { BasicPageComponent } from './app/basic-page/basic-page.component';
 import { MutationsPageComponent } from './app/mutations-page/mutations-page.component';
 import { InfiniteQueryPageComponent } from './app/infinite-query-page/infinite-query-page.component';
 import { PaginationPageComponent } from './app/pagination-page/pagination-page.component';
+import { SimplePageComponent } from './app/simple-page/simple-page.component';
 
 if (environment.production) {
   enableProdMode();
@@ -21,6 +22,10 @@ bootstrapApplication(AppComponent, {
         [
           {
             path: '',
+            component: SimplePageComponent,
+          },
+          {
+            path: 'basic',
             component: BasicPageComponent,
           },
           {


### PR DESCRIPTION
## Description

This PR is to add more examples describe in #4 with a simple fetch to ng-query and show its repo information. 

More examples will be added once the corresponding API is ready e.g pagination, mutation etc.

Technically we should follow what are the original examples from react-query so that users know what to expect.

## Screenshots

![image](https://user-images.githubusercontent.com/6767322/194743386-f01ee1c0-62d1-4ac8-b309-1e1acb2cdbc7.png)


## Question 

Are we plan to support normal `@Inject(QueryProvider) private useQuery: QueryType`? 
If so, we will need to export the `Query['query']`, not sure what to call it anyway 😂

![image](https://user-images.githubusercontent.com/6767322/194743485-bbe6f2ae-2d1a-485c-a2dc-71b2ee2cd32a.png)


## Follow up

We should update the repo description. Something like that? 

```
Angular wrapper for @tanstack/query 🔥 Powerful asynchronous state management, server-state utilities and data fetching library.
```

![image](https://user-images.githubusercontent.com/6767322/194743329-1595c7a4-5e83-4a1f-a19c-982431277f58.png)
