### PR TITLE
fix: useQuery with default TData type

### DIFF
--- a/packages/ng-query/src/lib/query.ts
+++ b/packages/ng-query/src/lib/query.ts
@@ -15,7 +15,12 @@ import { NgQueryObserverResult } from './types';
 class Query {
   private instance = inject(QueryClient);
 
-  use<TQueryFnData, TError, TData, TQueryData>(
+  use<
+    TQueryFnData,
+    TError = unknown,
+    TData = TQueryFnData,
+    TQueryData = TQueryFnData
+  >(
     queryKey: QueryKey,
     queryFn: (
       context: QueryFunctionContext<QueryKey>


### PR DESCRIPTION
## Explain the issue 

After #17 changes, we need to add the default type for `useQuery` so that `NgQueryObserverResult` gets infers the `TData` type properly.

Currently, some of the examples that use `useQuery` is failing.

I'll add more examples after this PR get merged

## Before

As `TData` is default to `unknown`, the `NgQueryObserverResult` get `unknown` type. Therefore some previous example is failing because we are accessing a value with type `unknown`.

![Screenshot 2022-10-13 at 10 48 47 PM](https://user-images.githubusercontent.com/6767322/195631976-c80bd3f7-4bf1-4f7c-9e3b-6a9c40506060.jpg)

![Monosnap ng-query 2022-10-13 22-52-20](https://user-images.githubusercontent.com/6767322/195631964-ea75d915-2962-415a-91ac-7777bdad81da.jpg)


## After

With the fix of `TData = TQueryFnData`, now the `Todo[]` is typed correctly.

![Screenshot 2022-10-13 at 10 52 44 PM](https://user-images.githubusercontent.com/6767322/195632034-a429dab2-2126-4877-84ef-5eea3f113dae.jpg)


